### PR TITLE
Improve fountain import export. Issue #2

### DIFF
--- a/src/myimport.py
+++ b/src/myimport.py
@@ -2,6 +2,7 @@ import config
 import gutil
 import misc
 import screenplay
+import titles
 import util
 
 from lxml import etree
@@ -394,7 +395,7 @@ def importFDX(fileName, frame):
 
 # import Fountain files.
 # http://fountain.io
-def importFountain(fileName, frame):
+def importFountain(fileName, frame, titlePages):
     # regular expressions for fountain markdown.
     # https://github.com/vilcans/screenplain/blob/master/screenplain/richstring.py
     ire = re.compile(
@@ -449,7 +450,8 @@ def importFountain(fileName, frame):
         return None
 
     inf = []
-    inf.append(misc.CheckBoxItem("Import titles as action lines."))
+    inf.append(misc.CheckBoxItem("Import titles to title page."))
+    inf.append(misc.CheckBoxItem("Import titles as action lines.",selected=False))
     inf.append(misc.CheckBoxItem("Remove unsupported formatting markup."))
     inf.append(misc.CheckBoxItem("Import section/synopsis as notes."))
 
@@ -458,11 +460,12 @@ def importFountain(fileName, frame):
 
     if dlg.ShowModal() != wx.ID_OK:
         dlg.Destroy()
-        return None
+        return None, titlePages
 
-    importTitles = inf[0].selected
-    removeMarkdown = inf[1].selected
-    importSectSyn = inf[2].selected
+    importTitlePage = inf[0].selected
+    importTitles = inf[1].selected
+    removeMarkdown = inf[2].selected
+    importSectSyn = inf[3].selected
 
     # pre-process data - fix newlines, remove boneyard.
     data = util.fixNL(data)
@@ -497,11 +500,79 @@ def importFountain(fileName, frame):
         l = util.toInputStr(prelines[0].expandtabs(tabWidth).lstrip().lower())
         if not l.startswith("fade") and l.count(":") == 1:
             # these are title lines. Now do what the user requested.
+            if importTitlePage:
+                #Extract usable title page lines
+                kwPattern = re.compile(r'^([A-za-z][^:]+:)')
+                continuePattern = re.compile(r'^\s\s\s+') # line begins with 3 or more spaces
+                titleIdx=0
+                gatheredTitles=[]
+                rejects=[]
+                l = prelines[0]
+                while l != '':
+                    match=kwPattern.split(l)
+                    match=[ll.strip() for ll in match]
+                    if len(match) == 3: # keyword line
+                        if match[2] == '':
+                            follows=[]
+                            titleIdx+=1 # gather indented prelines
+                            nextline = continuePattern.match(prelines[titleIdx])
+                            while nextline:
+                                follows.append(prelines[titleIdx].strip('_* \t'))
+                                titleIdx+=1
+                                nextline = continuePattern.match(prelines[titleIdx])
+                            titleIdx-=1
+                            gatheredTitles.append([match[1],follows])
+                        else:
+                            gatheredTitles.append([match[1],[match[2].strip('_* \t')]])
+                    else:
+                        l += TWOSPACE
+                        rejects.append(l)
+                    titleIdx+=1
+                    l=prelines[titleIdx]
+                # replace default titles with imported ones
+                leftX = 15.0
+                leftY = 220.0
+                centreX = 0.0
+                centreY = 150.0
+                for t in gatheredTitles:
+                    titlenr=-1
+                    if t[0] == 'Title:':
+                        titlenr=0
+                    elif t[0] == 'Author:' or t[0]=='Authors:':
+                        titlenr=1
+                        t[1]=["by",""]+t[1]
+                    elif t[0] == 'Contact:':
+                        titlenr=2
+                    else:
+                        titlenr=len(titlePages[0])
+                        if t[0] == 'Credit:' or t[0] == 'Source:':
+                            centred = True
+                            thisX = centreX
+                            thisY = centreY
+                            centreY += 5
+                        else:
+                            centred = False
+                            thisX = leftX
+                            thisY=leftY
+                            leftY -= 5
+                        if len(t[1])==1:
+                            newItems = [t[0]+" "+t[1][0]]
+                        else:
+                            newItems = [t[0]]+t[1]
+                        newTitleString = titles.TitleString(newItems, y = thisY, isCentered = centred)
+                        titlePages[0].append( newTitleString)
+                        continue
+                    targetTitle=titlePages[0][titlenr]
+                    targetTitle.items=t[1]
+                # user might request that titles go into both title page & script
+                if not importTitles:
+                    rejects += prelines[c+1:]
+                    prelines=rejects
             if importTitles:
                 # add TWOSPACE to all the title lines.
                 for i in range(c):
                     prelines[i] += TWOSPACE
-            else:
+            elif not importTitlePage:
                 #remove these lines
                 prelines = prelines[c+1:]
 
@@ -677,7 +748,7 @@ def importFountain(fileName, frame):
             ret.append(ln)
 
     makeLastLBLast()
-    return ret
+    return ret, titlePages
 
 # import text file from fileName, return list of Line objects for the
 # screenplay or None if something went wrong. returned list always

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -641,7 +641,6 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
         TWOSPACE = "  "
         sceneStartsList = ("INT", "EXT", "EST", "INT./EXT", "INT/EXT", "I/E", "I./E")
 
-
         # does s look like a fountain scene line:
         def looksLikeScene(s):
             s = s.upper()
@@ -651,6 +650,35 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
                     looksGood = True
                     break
             return looksGood
+
+        # Generate Title Page
+        def generateTitleString(keyword,titleLine,startAt,linePrefix, lineSuffix):
+            if (len(titleLine)-startAt)>1:
+                # multi-line
+                flines.append(keyword)
+                for part in titleLine:
+                    if startAt > 0:
+                        startAt -= 1
+                        continue
+                    flines.append('    '+linePrefix+part+lineSuffix)
+            elif len(titleLine) == 1 and keyword == titleLine[0]:
+                flines.append(keyword)
+            else:
+                flines.append(keyword+' '+titleLine[startAt])
+
+        titleNeeded=True
+        kwPattern = re.compile(r'^([A-za-z][^:]+:)')
+        for page in self.titles.pages:
+            for titleLine in page:
+                if titleNeeded and titleLine.isBold and titleLine.isCentered:
+                    generateTitleString('Title:',titleLine.items,0,'_**','**_')
+                    titleNeeded = False
+                elif titleLine.items[0]=='by':
+                    generateTitleString('Author:',titleLine.items,2,'','')
+                elif kwPattern.match(titleLine.items[0]):
+                    generateTitleString(titleLine.items[0],titleLine.items,0,'','')
+                else:
+                    generateTitleString('Contact:',titleLine.items,0,'','')
 
         for ele in eleList:
             typ, txt = ele

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -295,6 +295,7 @@ class MyCtrl(wx.Control):
             return False
 
     def importFile(self, fileName):
+        titlePages = False
         if fileName.endswith("fdx"):
             lines = myimport.importFDX(fileName, mainFrame)
         elif fileName.endswith("celtx"):
@@ -302,7 +303,7 @@ class MyCtrl(wx.Control):
         elif fileName.endswith("astx"):
             lines = myimport.importAstx(fileName, mainFrame)
         elif fileName.endswith("fountain"):
-            lines = myimport.importFountain(fileName, mainFrame)
+            lines, titlePages = myimport.importFountain(fileName, mainFrame, self.sp.titles.pages)
         elif fileName.endswith("fadein"):
             lines = myimport.importFadein(fileName, mainFrame)
         else:
@@ -314,6 +315,8 @@ class MyCtrl(wx.Control):
         self.createEmptySp()
 
         self.sp.lines = lines
+        if titlePages:
+            self.sp.titles.pages = titlePages
         self.sp.reformatAll()
         self.sp.paginate()
         self.sp.markChanged(True)


### PR DESCRIPTION
Resolves https://github.com/juliaclement/trelby/issues/2

On export, send lines from title pages to the .fountain file

On import, read entries in the title page section and add them to
page 0 of the title pages.

Title, Author and Title are matched to the default strings trelby
creates. Other lines in format kw: data are added as custom entries