### PR TITLE
Fix tab bar resolution on high dpi / Avoid triple buffering on Gtk

### DIFF
--- a/src/misc.py
+++ b/src/misc.py
@@ -437,13 +437,12 @@ class MyTabCtrl(wx.Window):
 
     def OnSize(self, event):
         size = self.GetClientSize()
-        self.screenBuf = wx.Bitmap(size.width, size.height)
 
     def OnEraseBackground(self, event):
         pass
 
     def OnPaint(self, event):
-        dc = wx.BufferedPaintDC(self, self.screenBuf)
+        dc = wx.BufferedPaintDC(self)
 
         cfgGui = self.getCfgGui()
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -442,7 +442,7 @@ class MyTabCtrl(wx.Window):
         pass
 
     def OnPaint(self, event):
-        dc = wx.BufferedPaintDC(self)
+        dc = wx.AutoBufferedPaintDCFactory(self)
 
         cfgGui = self.getCfgGui()
 


### PR DESCRIPTION
On high dpi screens, the tab bar had been rendered at a lower resolution and looked fuzzy:
![grafik](https://user-images.githubusercontent.com/8160319/184509546-09597009-c8b4-43c9-8c5c-089a1f700615.png)

Turns out, this has been an issue with the double-buffered `BufferedPaintDC` in wxWidgets: https://github.com/wxWidgets/Phoenix/issues/1542

Reading the issue discussion, I learned that you don't even need double-buffering using the Gtk backend, because Gtk already double-buffers everything. Using a `BufferedPaintDC` with backends like this results in triple buffering. That's why I decided to use `AutoBufferedPaintDCFactory`, which should create a `BufferedPaintDC` on systems like Windows that don't do double-buffering themselves and a normal `PaintDC` with toolkits that automatically double-buffer everything.

This is how it looks now on Gtk:

![grafik](https://user-images.githubusercontent.com/8160319/184509557-5d6e0b44-4d20-4cc3-bbf5-58add52923a6.png)

As you can see in my first commit, I could also make the tab bar render in high resolution without avoiding `BufferedPaintDC` by just not manually passing a buffer to it. The documentation made me assume that it should work without manually passing a buffer bitmap. But I'm not sure whether that commit works by breaking double buffering (or triple buffering on Gtk) or whether  `BufferedPaintDC` just behaves well on high dpi as long as you don't create the buffer by hand. Anyway, the `AutoBufferedPaintDCFactory` that I used in my second commit should explicitly avoid triple buffering on Gtk, which is a good thing anyway.

I have not tested this with any other backends than Gtk. But I heard that Trelby doesn't work on Windows right now anyway, so probably, no one can test this right now? Anyway, the worst things that can happen are
- this makes it still use double buffering on Windows, and therefore still renders at low resolution on Windows (this is what should happen if `AutoBufferedPaintDCFactory` works as it should)
- this fixes high resolution also an Windows, but breaks double buffering on Windows (will cause flickering on Windows)

I think these are minor issues for an operating system we don't support at the moment anyway.