### PR TITLE
Fix tab visual glitch on high dpi

### DIFF
--- a/src/misc.py
+++ b/src/misc.py
@@ -479,7 +479,7 @@ class MyTabCtrl(wx.Window):
                 points=((0,tabH),(4,2),(6,1),(tabW-8,1),(tabW-6,2),(tabW-2,tabH))
                 dc.SetBrush(cfgGui.workspaceBrush)
             else:
-                points=((0,tabH-separatorLineThickness),(3,3),(5,2),(tabW-8,2),(tabW-6,3),(tabW-2,tabH-separatorLineThickness))
+                points=((0,tabH-separatorLineThickness),(3,3),(5,2),(tabW-8,2),(tabW-6,3),(tabW-2,tabH-separatorLineThickness)) # subtract its thickness to not cover the separator line
                 dc.SetBrush(cfgGui.tabNonActiveBgBrush)
 
             dc.DestroyClippingRegion()

--- a/src/misc.py
+++ b/src/misc.py
@@ -437,13 +437,12 @@ class MyTabCtrl(wx.Window):
 
     def OnSize(self, event):
         size = self.GetClientSize()
-        self.screenBuf = wx.Bitmap(size.width, size.height)
 
     def OnEraseBackground(self, event):
         pass
 
     def OnPaint(self, event):
-        dc = wx.BufferedPaintDC(self, self.screenBuf)
+        dc = wx.BufferedPaintDC(self)
 
         cfgGui = self.getCfgGui()
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -453,7 +453,8 @@ class MyTabCtrl(wx.Window):
         dc.DrawRectangle(0, 0, w, h)
 
         dc.SetPen(cfgGui.tabBorderPen)
-        dc.DrawLine(0,h-1,w,h-1)
+        separatorLineThickness = cfgGui.tabBorderPen.GetWidth()
+        dc.DrawLine(0,h-separatorLineThickness,w,h-separatorLineThickness)
 
         xpos = self.paddingX
 
@@ -474,18 +475,24 @@ class MyTabCtrl(wx.Window):
             dc.SetFont(self.font)
             p = self.pages[i]
 
-            dc.DestroyClippingRegion()
-            dc.SetClippingRegion(xpos, tabY, tabW, tabH)
-            dc.SetPen(cfgGui.tabBorderPen)
-
             if i == self.selected:
-                points=((6,1),(tabW-8,1),(tabW-6,2),(tabW-2,tabH),(0,tabH),(4,2))
+                points=((0,tabH),(4,2),(6,1),(tabW-8,1),(tabW-6,2),(tabW-2,tabH))
                 dc.SetBrush(cfgGui.workspaceBrush)
             else:
-                points=((5,2),(tabW-8,2),(tabW-6,3),(tabW-2,tabH-1),(0,tabH-1),(3,3))
+                points=((0,tabH-separatorLineThickness),(3,3),(5,2),(tabW-8,2),(tabW-6,3),(tabW-2,tabH-separatorLineThickness))
                 dc.SetBrush(cfgGui.tabNonActiveBgBrush)
 
+            dc.DestroyClippingRegion()
+
+            # draw tab background
+            dc.SetClippingRegion(xpos, tabY, tabW, tabH)
+            dc.SetPen(wx.Pen(wx.NullPen))
             dc.DrawPolygon(points,xpos,tabY)
+
+            # draw tab borders
+            dc.SetClippingRegion(xpos, tabY, tabW, tabH-separatorLineThickness) # tab borders should never cross the seperator line
+            dc.SetPen(cfgGui.tabBorderPen)
+            dc.DrawLines(points,xpos,tabY)
 
             # clip the text to fit within the tabs
             dc.DestroyClippingRegion()

--- a/src/misc.py
+++ b/src/misc.py
@@ -442,7 +442,7 @@ class MyTabCtrl(wx.Window):
         pass
 
     def OnPaint(self, event):
-        dc = wx.BufferedPaintDC(self)
+        dc = wx.AutoBufferedPaintDCFactory(self)
 
         cfgGui = self.getCfgGui()
 


### PR DESCRIPTION
The tab should melt with the view below it, by cutting a hole into the separator line that separates the tab bar from the widget below.

This was achieved by drawing the tab background over the separator line, covering it.

Also, the tab shouldn't have a bottom border itself, obviously.

This was achieved by drawing a full polygon with full borders for the tab background, but limiting it by a clipping region, so the bottom border was cut off (as it was drawn outside the boundaries of the clipping region). This broke on high dpi screens, as the sizes for the clipping box and the tab were calculated on pixel basis, and didn't line up with higher precision:

![grafik](https://user-images.githubusercontent.com/8160319/184509557-5d6e0b44-4d20-4cc3-bbf5-58add52923a6.png)

Therefore, you could see the bottom line of the tab background.

Making the clipping region 1px smaller, however, made the background not fully cover the separator line anymore:

![grafik](https://user-images.githubusercontent.com/8160319/184514181-5fb8d9da-e947-4000-99ea-61c057612446.png)

(we can only move in px steps, as the wxWidget methods only take ints)

This commit fixes this, by drawing the background first as a polygon (without borders) and then draw the borders (without the bottom border). However, in this case, the side borders will still overlap the separator line:

![image](https://user-images.githubusercontent.com/8160319/184528470-9e7b1790-d159-402b-a8ec-2e74612da867.png)

That's why I draw the borders with a smaller clipping region, so they can be drawn using the same points but don't cross the separator line.

Now it looks like this:
![grafik](https://user-images.githubusercontent.com/8160319/184513947-f01b31e3-7a5d-4a34-91d9-d626fa7e038c.png)

Don't merge before #23!