### PR TITLE
Fix Python < 3.9 compatibility

### DIFF
--- a/src/myimport.py
+++ b/src/myimport.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import config
 import gutil
@@ -742,7 +742,7 @@ def importFountain(fileName, frame, titlePages):
 # import text file from fileName, return list of Line objects for the
 # screenplay or None if something went wrong. returned list always
 # contains at least one line.
-def importTextFile(fileName: str, frame: wx.Frame)->Optional[list[screenplay.Line]]:
+def importTextFile(fileName: str, frame: wx.Frame)->Optional[List[screenplay.Line]]:
 
     # the 1 MB limit is arbitrary, we just want to avoid getting a
     # MemoryError exception for /dev/zero etc.

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -23,6 +23,8 @@ SHOT = 7
 NOTE = 8
 ACTBREAK = 9
 
+from typing import tuple
+
 import autocompletion
 import config
 import error

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -23,7 +23,7 @@ SHOT = 7
 NOTE = 8
 ACTBREAK = 9
 
-from typing import tuple
+from typing import Tuple
 
 import autocompletion
 import config
@@ -410,7 +410,7 @@ class Screenplay:
     # already. returns a (key, value) tuple. if line doesn't match the
     # format, (None, None) is returned.
     @staticmethod
-    def parseConfigLine(s: str)->tuple[str,str]:
+    def parseConfigLine(s: str)->Tuple[str,str]:
         pattern = re.compile("#([a-zA-Z0-9\-]+) (.*)")
         m = pattern.search(s)
         if m:


### PR DESCRIPTION
In Python < 3.9, some built-in types don't allow generics. According to #34, this seems to include the type `tuple`.

https://stackoverflow.com/questions/63460126/typeerror-type-object-is-not-subscriptable-in-a-function-signature suggests that you can fix this by importing these types equivalents from the `typing` namespace. This is what this commit does.

Fixes #34