### PR TITLE
Run CI for pushes on main and for all Pull Requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,8 @@
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
-    branches:
-    - master
 
 name: Run Tox tests
 


### PR DESCRIPTION
The CI was configured to only run for PRs against and commits pushed to the branch `master`. But our current default branch is called `main`.

Also, CI will now run on PRs targeting any branch.