### PR TITLE
Install dependencies from requirements.txt in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist = py39
 
 [testenv]
 deps =
-    wxPython
-    lxml
+    -rrequirements.txt
 allowlist_externals =
     make
 commands = 


### PR DESCRIPTION
The reason for CI failing currently (as seen in https://github.com/limburgher/trelby/actions/runs/3315341708) is that some dependencies are not present in tox.ini. Instead of maintaining dependencies at two places, I think it's better to use the requirements.txt from tox.