### PR TITLE
Change default position of popup window

### DIFF
--- a/src/cfgdlg.py
+++ b/src/cfgdlg.py
@@ -141,7 +141,7 @@ class CfgDlg(wx.Dialog):
 
         self.SetSizerAndFit(vsizer)
         self.Layout()
-        self.Center()
+        # self.Center()
 
         self.Bind(wx.EVT_BUTTON, self.OnApply, id=applyBtn.GetId())
         self.Bind(wx.EVT_BUTTON, self.OnCancel, id=cancelBtn.GetId())

--- a/src/commandsdlg.py
+++ b/src/commandsdlg.py
@@ -9,7 +9,7 @@ class CommandsDlg(wx.Frame):
         wx.Frame.__init__(self, None, -1, "Commands",
                           size = (650, 600), style = wx.DEFAULT_FRAME_STYLE)
 
-        self.Center()
+        # self.Center()
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(vsizer)

--- a/src/finddlg.py
+++ b/src/finddlg.py
@@ -146,7 +146,6 @@ class FindDlg(wx.Dialog):
             self.elements.Check(i, tmp[i])
 
         self.showExtra(self.ctrl.findDlgUseExtra)
-        self.Center()
 
     def saveState(self):
         self.getParams()

--- a/src/util.py
+++ b/src/util.py
@@ -637,7 +637,7 @@ def drawText(dc, text, x, y, align = ALIGN_LEFT, valign = VALIGN_TOP):
 # create pad sizer for given window whose controls are in topSizer, with
 # 'pad' pixels of padding on each side, resize window to correct size, and
 # optionally center it.
-def finishWindow(window, topSizer, pad = 10, center = True):
+def finishWindow(window, topSizer, pad = 10, center = False):
     padSizer = wx.BoxSizer(wx.VERTICAL)
     padSizer.Add(topSizer, 1, wx.EXPAND | wx.ALL, pad)
     window.SetSizerAndFit(padSizer)


### PR DESCRIPTION
All popups, with the exceptions of of errors, and information popups are now put in the top left corner instead of in the center. Like discussed in #40 