### PR TITLE
Fix names dialog not appearing

### DIFF
--- a/src/namesdlg.py
+++ b/src/namesdlg.py
@@ -122,7 +122,7 @@ class NamesDlg(wx.Dialog):
         self.sexRb.SetSelection(2)
         hsizer2.Add(self.sexRb, 0, wx.LEFT, 5)
 
-        vsizer.Add(hsizer2, 0, wx.EXPAND | wx.ALIGN_CENTER)
+        vsizer.Add(hsizer2, 0, wx.EXPAND)
 
         vsizer.Add(wx.StaticText(self, -1, "Results:"))
 


### PR DESCRIPTION
Before this change, the names dictionary dialog does not appear when the menu item is selected, and the console emits the following warning:

```
wxEXPAND overrides alignment flags in box sizers
```

This change removes the alignment flag to allow the window to display.

---

Different combinations flags are used throughout the application, happy to update the pull request if there is a specific combination that's best used for this dialog window.