### PR TITLE
Fix encoding in PDFs

### DIFF
--- a/src/pdf.py
+++ b/src/pdf.py
@@ -302,7 +302,7 @@ class PDFExporter:
             for i in range(len(doc.tocs)):
                 self.genOutline(i)
 
-        return self.genPDF()
+        return util.toLatin1(self.genPDF())
 
     def createInfoObj(self):
         version = self.escapeStr(self.doc.version)


### PR DESCRIPTION
With Python 3, the default string encoding changed from Latin1 to UTF-8. e294939d9e1248e8f62ade019699ed7028742946 took care of removing redundant conversions to UTF-8 at places where UTF-8 is needed (like exporting .fountain files), but it did not introduce conversions to Latin1 where Latin1 is needed (like writing PDFs).

This resulted in non-ASCII characters, which are actually part of Latin1 (like äöüß) to not be rendered correctly in PDFs. If you run the Trelby version from the master branch of trelby/trelby or from the [trelby.org](https://www.trelby.org) (which still runs on Python 2), you can see that it exports characters like these correctly.

Only non-Latin characters (like greek, chinese, etc.) are not displayed correctly even if the font supports it, which is a different problem. That problem was reported in https://web.archive.org/web/20201226153814/https://github.com/oskusalerma/trelby/issues/85, and it can be fixed by #59.

This is a very simple fix which I expect to have no side effects and can be merged immediately. It closes #21.