### PR TITLE
Update the way pytest is found on the PATH for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,9 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 -r requirements.txt
+        - name: Ensure pytest is available on PATH
+          run: echo "/opt/trelby/bin" >> "$GITHUB_PATH"
         - name: Test with pytest
           env:
             PYTHONPATH: /opt/trelby
-          run: |
-            /opt/trelby/bin/pytest
+          run: pytest


### PR DESCRIPTION
This change fixes an issue where pytest cannot be found under Python 3.10, resulting in tests executing as expected under all of 3.8, 3.9, and 3.10.