### PR TITLE
Fix wxPython installation for Python 3.11 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,42 @@ jobs:
 
       steps:
         - uses: actions/checkout@v3
+
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
+
+        - uses: actions/cache/restore@v3
+          id: restore-cache
+          with:
+            path: ${{ env.pythonLocation }}
+            key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+
         - name: Install Linux dependencies
           run: |
-            sudo apt-get install libsdl2-2.0 libwxgtk3.0-gtk3-dev
+            sudo apt-get install libgtk-3-dev libsdl2-2.0 libwxgtk3.0-gtk3-dev
+
         - name: Install Python dependencies
           run: |
-            python -m pip install --upgrade pip
+            python -m pip install --upgrade pip wheel
+            # Install attrdict3 to support the installation of wxPython from source.
+            # In most cases, wxPython can be installed from wheels, but if those are not available,
+            # attrdict3 is a prerequisite for installing from source.
+            # This is currently a requirement for installing wxPython for Python 3.11.
+            python -m pip install attrdict3
             pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 -r requirements.txt
+
+
+        - uses: actions/cache/save@v3
+          if: steps.restore-cache.outputs.cache-hit != 'true'
+          with:
+            path: ${{ env.pythonLocation }}
+            key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+
         - name: Ensure pytest is available on PATH
           run: echo "/opt/trelby/bin" >> "$GITHUB_PATH"
+
         - name: Test with pytest
           env:
             PYTHONPATH: /opt/trelby


### PR DESCRIPTION
This change allows the test suite to run under Python 3.11 by adding steps to install `libgtk-3-dev` and `attrdict3` as build-time dependencies required to install `wxPython` from source. Building from a source distribution is required at this time because there are currently no pre-built wheels for `wxPython` in the remote package directory. If / when wheels for 3.11 become available upstream, this setup should prefer the wheels like it does in the 3.8 - 3.10 environments and avoid building from source without any other changes necessary.

This also includes a caching setup for the Python environment used by the test runners. Without the cached installed packages ([example GitHub Actions run with a cold cache](https://github.com/jonafato/trelby/actions/runs/4451890064)), the install step takes 30+ minutes. However, after building `wxPython` from source once and caching the installed dependencies ([GitHub Actions run with a warm cache](https://github.com/jonafato/trelby/actions/runs/4453048397)), the 3.11 environment runs the test suite on par with or faster than the other supported versions.

A potential issue with the cache key in the short term: the key is based on (among other things) the hashed contents of the `requirements.txt` file. This is a fine approach, but it can lead to a cache invalidation issue in this specific case due to the fact that the `requirements.txt`  file does not pin versions, which may result in an older version of a dependency being loaded from the cache than is wanted once new dependency releases get published. If this invalidation issue does cause an issue for a given pull request, the key format in the action configuration file can be modified explicitly to force a new installation without cache contents. A permanent  fix for this issue is to pin dependencies (possibly with the help of a tool like [`pip-compile`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile)), upgrading to newer dependency versions as needed or on a schedule.

The end result of these changes is that the test suite now runs against all four versions of Python listed in the configuration file. (The remaining test failures are actual test failures that need code fixes outside of the scope of this actions config change.)