### PR TITLE
Fix PDF preview (via print)

### DIFF
--- a/src/characterreport.py
+++ b/src/characterreport.py
@@ -1,3 +1,5 @@
+from typing import AnyStr
+
 import misc
 import pdf
 import pml
@@ -86,7 +88,7 @@ class CharacterReport:
     def sum(self, name):
         return reduce(lambda tot, ci: tot + getattr(ci, name), self.cinfo, 0)
 
-    def generate(self) -> str:
+    def generate(self) -> AnyStr:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 20.0, 12)
 

--- a/src/dialoguechart.py
+++ b/src/dialoguechart.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, AnyStr
 
 import gutil
 import misc
@@ -173,7 +173,7 @@ class DialogueChart:
         # spacing from one legend item to next
         self.legendSize = 4.0
 
-    def generate(self, cbil: List[misc.CheckBoxItem]) -> str:
+    def generate(self, cbil: List[misc.CheckBoxItem]) -> AnyStr:
         doc = pml.Document(self.sp.cfg.paperHeight,
                            self.sp.cfg.paperWidth)
 

--- a/src/gutil.py
+++ b/src/gutil.py
@@ -1,3 +1,5 @@
+from typing import AnyStr
+
 import config
 from error import MiscError,TrelbyError
 import misc
@@ -73,7 +75,7 @@ def btnDblClick(btn, func):
 # temporary file, first deleting all old temporary files, then opens PDF
 # viewer application. 'mainFrame' is used as a parent for message boxes in
 # case there are any errors.
-def showTempPDF(pdfData: str, cfgGl: 'config.ConfigGlobal', mainFrame: wx.TopLevelWindow) -> None:
+def showTempPDF(pdfData: AnyStr, cfgGl: 'config.ConfigGlobal', mainFrame: wx.TopLevelWindow) -> None:
     try:
         try:
             util.removeTempFiles(misc.tmpPrefix)
@@ -82,7 +84,10 @@ def showTempPDF(pdfData: str, cfgGl: 'config.ConfigGlobal', mainFrame: wx.TopLev
                                             suffix = ".pdf")
 
             try:
-                os.write(fd, pdfData.encode("UTF-8"))
+                if isinstance(pdfData, str):
+                    os.write(fd, pdfData.encode("UTF-8"))
+                else:
+                    os.write(fd, pdfData)
             finally:
                 os.close(fd)
 

--- a/src/locationreport.py
+++ b/src/locationreport.py
@@ -1,3 +1,5 @@
+from typing import AnyStr
+
 import misc
 import pdf
 import pml
@@ -62,7 +64,7 @@ class LocationReport:
         for s in ["Speakers"]:
             self.inf.append(misc.CheckBoxItem(s))
 
-    def generate(self) -> str:
+    def generate(self) -> AnyStr:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 

--- a/src/pdf.py
+++ b/src/pdf.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Dict
+from typing import Optional, List, Tuple, Dict, AnyStr
 
 import fontinfo
 import pml
@@ -12,7 +12,7 @@ TRANSFORM_MATRIX = {
 }
 
 # users should only use this.
-def generate(doc: 'pml.Document') -> str:
+def generate(doc: 'pml.Document') -> AnyStr:
     tmp = PDFExporter(doc)
     return tmp.generate()
 
@@ -200,7 +200,7 @@ class PDFExporter:
         self.doc: pml.Document = doc
 
     # generate PDF document and return it as a string
-    def generate(self) -> str:
+    def generate(self) -> AnyStr:
         #lsdjflksj = util.TimerDev("generate")
         doc = self.doc
 

--- a/src/scenereport.py
+++ b/src/scenereport.py
@@ -1,3 +1,5 @@
+from typing import AnyStr
+
 import misc
 import pdf
 import pml
@@ -36,7 +38,7 @@ class SceneReport:
         for s in ["Speakers"]:
             self.inf.append(misc.CheckBoxItem(s))
 
-    def generate(self) -> str:
+    def generate(self) -> AnyStr:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -23,7 +23,7 @@ SHOT = 7
 NOTE = 8
 ACTBREAK = 9
 
-from typing import Tuple
+from typing import Tuple, AnyStr
 
 import autocompletion
 import config
@@ -826,7 +826,7 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
     # 100% correct for the screenplay. isExport is True if this is an
     # "export to file" operation, False if we're just going to launch a
     # PDF viewer with the data.
-    def generatePDF(self, isExport: bool) -> str:
+    def generatePDF(self, isExport: bool) -> AnyStr:
         return pdf.generate(self.generatePML(isExport))
 
     # Same arguments as generatePDF, but returns a PML document.

--- a/src/scriptreport.py
+++ b/src/scriptreport.py
@@ -1,3 +1,5 @@
+from typing import AnyStr
+
 import characterreport
 import config
 import pdf
@@ -12,7 +14,7 @@ class ScriptReport:
         self.sr = scenereport.SceneReport(sp)
         self.cr = characterreport.CharacterReport(sp)
 
-    def generate(self) -> str:
+    def generate(self) -> AnyStr:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 


### PR DESCRIPTION
When I changed the encoding of PDF files from UTF-8 to Latin1 in #60, I didn't realise that this changed the return type of PDFGenerator.generate(). This wasn't a problem for exporting PDFs, as the methods used there already could deal with `AnyStr` (which means either the default UTF-8 encoded Python string or `bytes` encoded with another encoding), but the method for temporarily saving a PDF couldn't. This broke the PDF preview function.

I already adjusted everything to support `AnyStr` in #59, so I cherry-picked it from there.