### PR TITLE
Be more specific about PDF generation return type

### DIFF
--- a/src/characterreport.py
+++ b/src/characterreport.py
@@ -88,7 +88,7 @@ class CharacterReport:
     def sum(self, name):
         return reduce(lambda tot, ci: tot + getattr(ci, name), self.cinfo, 0)
 
-    def generate(self) -> AnyStr:
+    def generate(self) -> bytes:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 20.0, 12)
 

--- a/src/dialoguechart.py
+++ b/src/dialoguechart.py
@@ -173,7 +173,7 @@ class DialogueChart:
         # spacing from one legend item to next
         self.legendSize = 4.0
 
-    def generate(self, cbil: List[misc.CheckBoxItem]) -> AnyStr:
+    def generate(self, cbil: List[misc.CheckBoxItem]) -> bytes:
         doc = pml.Document(self.sp.cfg.paperHeight,
                            self.sp.cfg.paperWidth)
 

--- a/src/gutil.py
+++ b/src/gutil.py
@@ -75,7 +75,7 @@ def btnDblClick(btn, func):
 # temporary file, first deleting all old temporary files, then opens PDF
 # viewer application. 'mainFrame' is used as a parent for message boxes in
 # case there are any errors.
-def showTempPDF(pdfData: AnyStr, cfgGl: 'config.ConfigGlobal', mainFrame: wx.TopLevelWindow) -> None:
+def showTempPDF(pdfData: bytes, cfgGl: 'config.ConfigGlobal', mainFrame: wx.TopLevelWindow) -> None:
     try:
         try:
             util.removeTempFiles(misc.tmpPrefix)
@@ -84,10 +84,7 @@ def showTempPDF(pdfData: AnyStr, cfgGl: 'config.ConfigGlobal', mainFrame: wx.Top
                                             suffix = ".pdf")
 
             try:
-                if isinstance(pdfData, str):
-                    os.write(fd, pdfData.encode("UTF-8"))
-                else:
-                    os.write(fd, pdfData)
+                os.write(fd, pdfData)
             finally:
                 os.close(fd)
 

--- a/src/locationreport.py
+++ b/src/locationreport.py
@@ -64,7 +64,7 @@ class LocationReport:
         for s in ["Speakers"]:
             self.inf.append(misc.CheckBoxItem(s))
 
-    def generate(self) -> AnyStr:
+    def generate(self) -> bytes:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 

--- a/src/pdf.py
+++ b/src/pdf.py
@@ -12,7 +12,7 @@ TRANSFORM_MATRIX = {
 }
 
 # users should only use this.
-def generate(doc: 'pml.Document') -> AnyStr:
+def generate(doc: 'pml.Document') -> bytes:
     tmp = PDFExporter(doc)
     return tmp.generate()
 
@@ -200,7 +200,7 @@ class PDFExporter:
         self.doc: pml.Document = doc
 
     # generate PDF document and return it as a string
-    def generate(self) -> AnyStr:
+    def generate(self) -> bytes:
         #lsdjflksj = util.TimerDev("generate")
         doc = self.doc
 

--- a/src/scenereport.py
+++ b/src/scenereport.py
@@ -38,7 +38,7 @@ class SceneReport:
         for s in ["Speakers"]:
             self.inf.append(misc.CheckBoxItem(s))
 
-    def generate(self) -> AnyStr:
+    def generate(self) -> bytes:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -826,7 +826,7 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
     # 100% correct for the screenplay. isExport is True if this is an
     # "export to file" operation, False if we're just going to launch a
     # PDF viewer with the data.
-    def generatePDF(self, isExport: bool) -> AnyStr:
+    def generatePDF(self, isExport: bool) -> bytes:
         return pdf.generate(self.generatePML(isExport))
 
     # Same arguments as generatePDF, but returns a PML document.
@@ -2482,7 +2482,7 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
 
     # compare this script to sp2 (Screenplay), return a PDF file (as a
     # string) of the differences, or None if the scripts are identical.
-    def compareScripts(self, sp2) -> str:
+    def compareScripts(self, sp2) -> bytes:
         s1 = self.generateText(False).split("\n")
         s2 = sp2.generateText(False).split("\n")
 

--- a/src/scriptreport.py
+++ b/src/scriptreport.py
@@ -14,7 +14,7 @@ class ScriptReport:
         self.sr = scenereport.SceneReport(sp)
         self.cr = characterreport.CharacterReport(sp)
 
-    def generate(self) -> AnyStr:
+    def generate(self) -> bytes:
         tf = pml.TextFormatter(self.sp.cfg.paperWidth,
                                self.sp.cfg.paperHeight, 15.0, 12)
 


### PR DESCRIPTION
This PR applies the changes requested by @jonafato in #69: We know that the pdf data will be `bytes` and don't need to use the less specific `AnyStr`. This saves us one if condition when saving.