### PR TITLE
Experiment: Let wx.ScrolledView handle scrolling to enable horizontal scrolling

### DIFF
--- a/src/trelby.py
+++ b/src/trelby.py
@@ -156,14 +156,14 @@ class GlobalData:
     def saveScDict(self):
         util.writeToFile(self.scDictFilename, self.scDict.save(), mainFrame)
 
-class MyPanel(wx.Panel):
+class MyPanel(wx.ScrolledWindow):
 
     def __init__(self, parent, id):
-        wx.Panel.__init__(
+        wx.ScrolledWindow.__init__(
             self, parent, id,
             # wxMSW/Windows does not seem to support
             # wx.NO_BORDER, which sucks
-            style = wx.WANTS_CHARS | wx.NO_BORDER)
+            style = wx.WANTS_CHARS | wx.NO_BORDER | wx.HSCROLL)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -178,6 +178,8 @@ class MyPanel(wx.Panel):
         self.scrollBarVertical.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
 
         self.SetSizer(hsizer)
+        self.SetScrollRate(int(self.ctrl.chX), int(self.ctrl.chY))
+        self.EnableScrolling(True, False)
 
     # we never want the scrollbar to get the keyboard focus, pass it on to
     # the main widget
@@ -435,6 +437,8 @@ class MyCtrl(wx.Control):
 
     def updateScreen(self, redraw = True, setCommon = True):
         self.adjustScrollBar()
+        self.SetMinSize(wx.Size(int(self.pageW), 10)) # the vertical min size is irrelevant currently, as vertical scrolling is still self-implemented
+        self.PostSizeEventToParent()
 
         if setCommon:
             self.updateCommon()

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -167,15 +167,15 @@ class MyPanel(wx.Panel):
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.scrollBar = wx.ScrollBar(self, -1, style = wx.SB_VERTICAL)
+        self.scrollBarVertical = wx.ScrollBar(self, -1, style = wx.SB_VERTICAL)
         self.ctrl = MyCtrl(self, -1)
 
         hsizer.Add(self.ctrl, 1, wx.EXPAND)
-        hsizer.Add(self.scrollBar, 0, wx.EXPAND)
+        hsizer.Add(self.scrollBarVertical, 0, wx.EXPAND)
 
-        self.scrollBar.Bind(wx.EVT_COMMAND_SCROLL, self.ctrl.OnScroll)
+        self.scrollBarVertical.Bind(wx.EVT_COMMAND_SCROLL, self.ctrl.OnScroll)
 
-        self.scrollBar.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
+        self.scrollBarVertical.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
 
         self.SetSizer(hsizer)
 
@@ -417,8 +417,8 @@ class MyCtrl(wx.Control):
         # about draft / layout mode differences.
         approx = int(((height / self.mm2p) / self.chY) / 1.3)
 
-        self.panel.scrollBar.SetScrollbar(self.sp.getTopLine(), approx,
-            len(self.sp.lines) + approx - 1, approx)
+        self.panel.scrollBarVertical.SetScrollbar(self.sp.getTopLine(), approx,
+                                                  len(self.sp.lines) + approx - 1, approx)
 
     def clearAutoComp(self):
         if self.sp.clearAutoComp():
@@ -611,7 +611,7 @@ class MyCtrl(wx.Control):
         self.updateScreen()
 
     def OnScroll(self, event):
-        pos = self.panel.scrollBar.GetThumbPosition()
+        pos = self.panel.scrollBarVertical.GetThumbPosition()
         self.sp.setTopLine(pos)
         self.sp.clearAutoComp()
         self.updateScreen()

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -163,7 +163,7 @@ class MyPanel(wx.ScrolledWindow):
             self, parent, id,
             # wxMSW/Windows does not seem to support
             # wx.NO_BORDER, which sucks
-            style = wx.WANTS_CHARS | wx.NO_BORDER | wx.HSCROLL)
+            style = wx.WANTS_CHARS | wx.NO_BORDER | wx.HSCROLL | wx.VSCROLL)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -171,7 +171,6 @@ class MyPanel(wx.ScrolledWindow):
         self.ctrl = MyCtrl(self, -1)
 
         hsizer.Add(self.ctrl, 1, wx.EXPAND)
-        hsizer.Add(self.scrollBarVertical, 0, wx.EXPAND)
 
         self.scrollBarVertical.Bind(wx.EVT_COMMAND_SCROLL, self.ctrl.OnScroll)
 
@@ -179,7 +178,7 @@ class MyPanel(wx.ScrolledWindow):
 
         self.SetSizer(hsizer)
         self.SetScrollRate(int(self.ctrl.chX), int(self.ctrl.chY))
-        self.EnableScrolling(True, False)
+        self.EnableScrolling(True, True)
 
     # we never want the scrollbar to get the keyboard focus, pass it on to
     # the main widget
@@ -188,7 +187,7 @@ class MyPanel(wx.ScrolledWindow):
 
 class MyCtrl(wx.Control):
 
-    def __init__(self, parent, id):
+    def __init__(self, parent: MyPanel, id):
         style = wx.WANTS_CHARS | wx.FULL_REPAINT_ON_RESIZE | wx.NO_BORDER
         wx.Control.__init__(self, parent, id, style = style)
 
@@ -435,9 +434,13 @@ class MyCtrl(wx.Control):
         else:
             return True
 
+    def getVisibleAreaSize(self):
+        ''' Size of the area visble in the scrolled window'''
+        return self.panel.GetSize()
+
     def updateScreen(self, redraw = True, setCommon = True):
         self.adjustScrollBar()
-        self.SetMinSize(wx.Size(int(self.pageW), 10)) # the vertical min size is irrelevant currently, as vertical scrolling is still self-implemented
+        self.SetMinSize(wx.Size(int(self.pageW), gd.vm.getDocumentHeight(self)))
         self.PostSizeEventToParent()
 
         if setCommon:


### PR DESCRIPTION
In order to enable zooming (#20), we need to implement horizontal scrolling first.

Currently, scrolling is implemented by saving the first line to be displayed (called `topLine`) on the Screenplay object. The rendering code always renders the page beginning with that line until the screen is filled. So you just need to change the current `topLine` to make the page scroll. This is what all scrolling-related code does currently.

Opposed to that, the wx.ScrolledWindow knows the size of its child and its own size and implements scrolling automatically based on that. It saves the current scroll position internally (based on pixels). This allows it to reuse a lot of the implementation from the native toolkits (e. g. Gtk), which gives us goodies as:

- horizontal scrolling: if the window is to narrow (or the screenplay is too wide), it will scroll horizontally
- the scroll bar will be shown and hidden automatically depending on whether you're able to scroll (in the current implementation, you can always scroll, even if it's of no use as the whole document fits on the screen)
- "precise scrolling" on Gtk: Have you ever noticed that when holding down a Gtk scroll bar, it scrolls slower and more precisely? This would have never been possible with the previous line-based scrolling, using wx.ScrolledView, we get it for free
- Smoother scrolling: in the current implementation, Trelby can only scroll in line steps, which doesn't look so smooth. wx.ScrolledView scrolls in pixel steps which looks a bit smoother
- Inertial scrolling on Gtk: On Gtk, we even get inertial scrolling for free
- Touch screen scrolling on Gtk: On Gtk, we also get touch screen scrolling for free
- Visualisation if the page continues on Gtk: On Gtk, we get shadows that indicate that the page is still scrollable in a certain direction (that disappear when the end is reached)

### Unsolved problems

Trelby's implementation relies heavily on the current line-based scrolling. Unsolved problems include (and might not be limited to):

- The rendering code of all view modes need to be adjusted to support this (I only adjusted the "Draft" view mode in this PR)
- The "makeLineVisible" code (that automatically scrolls to make a certain line visible, imagine you scrolled away from the current text cursor position and start typing again) needs to be adjusted (I fiddled around with this in this PR, but it's certainly not ready)
- Instead of only rendering the visible parts of the document, we now render the whole document, keep it in memory and scroll in it. I haven't done benchmarks on this, but this certainly takes more memory on large documents.
- Probably there is more lacking that I don't see yet

Because of these reasons, I'm not sure if I will ever finish this. But I wanted to share this anyway.