### PR TITLE
Fix installation (e. g. to "/opt" or a custom location)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,26 @@
 # setup.py
 from distutils.command.build_scripts import build_scripts as _build_scripts
+from setuptools.command.easy_install import easy_install as _easy_install
 from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from distutils.command.install_data import install_data as _install_data
 from distutils.core import Command
 from distutils.core import setup
 from distutils.util import convert_path
 
-import fileinput
 import glob
 import subprocess
 import sys
 import os.path
+
+
+def modify_import_path_in_trelby_bin(path_to_trelby_bin: str, src_path_in_final_installation: str):
+    in_file = open(path_to_trelby_bin, "rt")
+    text = in_file.read()
+    text = text.replace('src', src_path_in_final_installation)
+    in_file.close()
+    out_file = open(path_to_trelby_bin, "wt")
+    out_file.write(text)
+    out_file.close()
 
 class build_scripts(_build_scripts):
     """build_scripts command
@@ -23,22 +33,29 @@ class build_scripts(_build_scripts):
         _build_scripts.copy_scripts(self)
 
         if "install" in self.distribution.command_obj:
+            if "bdist_egg" in self.distribution.command_obj:
+                # When creating an egg, the paths here don't match the final paths, as the egg is going to get moved
+                # later on by the easy_install command. The easy_install command is going to take care of modifying the
+                # import path then.
+                return
+
             iobj = self.distribution.command_obj["install"]
             libDir = iobj.install_lib
 
             if iobj.root:
                 libDir = libDir[len(iobj.root):]
 
-            script = convert_path("bin/trelby")
-            outfile = os.path.join(self.build_dir, os.path.basename(script))
+            path_to_trelby_bin = os.path.join(self.build_dir, os.path.basename(convert_path("bin/trelby")))
 
-            in_file = open(script, "rt")
-            text = in_file.read()
-            text = text.replace('src', libDir + 'src')
-            in_file.close()
-            out_file = open(outfile, "wt")
-            out_file.write(text)
-            out_file.close()
+            modify_import_path_in_trelby_bin(path_to_trelby_bin, os.path.join(libDir, 'src'))
+
+class easy_install(_easy_install):
+    def install_egg(self, egg_path, tmpdir):
+        egg_distribution = super().install_egg(egg_path, tmpdir)
+
+        modify_import_path_in_trelby_bin(os.path.join(egg_distribution.egg_info, 'scripts/trelby'), os.path.join(egg_distribution.location, 'src'))
+
+        return egg_distribution
 
 class bdist_rpm(_bdist_rpm):
     """bdist_rpm command
@@ -174,6 +191,7 @@ setup(
         "build_scripts": build_scripts,
         "bdist_rpm": bdist_rpm,
         "install_data": install_data,
+        "easy_install": easy_install,
         "nsis": nsis,
     },
     version = misc.version,


### PR DESCRIPTION
Depending on how trelby is installed, the `src` directory will be copied to different places. The `bin/trelby` script needs to know about that location, so it can start the application. That's why the installation process in `setup.py` rewrites the code that `bin/trelby` uses to import the `src` files.

So no matter whether you create e. g. an rpm using `setup.py bdist_rpm` or install Trelby to `/opt` using `setup.py install`, the `trelby` script in `bin` should import the trelby source code files from the right location and be able to load them.

But this behaviour was broken for the `install` command:

When using the `install` command, setup.py will first create an egg in a build dir and make all the installation steps in there, as if this was the final installation. Only then, the `easy_install` step copies the .egg to the final location specified by the user (e. g. `/opt`).

Because of this, the code that rewrote the import path wrote a relative path from inside the build directory into the file, which of course was invalid in the final installation directory.

To get the final final installation directory, I needed to hook into the `easy_install` command and do the rewrite there.

Probably this broke because distutils changed the way the `install` step works by introducing `easy_install`.

After this commit, it works reliably for `setup.py install` to any location. Because I also left the old code where it was (and only skip it when an egg is being build), `setup.py bdist_rpm` (which doesn't build and egg and doesn't use `easy_install`) continues to work as expected. I couldn't test builiding debs as I don't get how to install the dependencies for this, but as rpms work I assume this is also going to continue working.

Fixes  #35