### PR TITLE
Fix Ubuntu package installation in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
 
         - name: Install Linux dependencies
           run: |
+            sudo apt-get update
             sudo apt-get install libgtk-3-dev libsdl2-2.0 libwxgtk3.0-gtk3-dev
 
         - name: Install Python dependencies


### PR DESCRIPTION
All CI checks currently fail, because `apt` uses an outdated package cache. That's why I added the `apt update` command, so it refreshes the package cache on every CI run.

The CI checks for our two older Python versions still fail. I have no clue why they do. But it seems to have nothing to do with `apt`, but rather with `pip`.