### PR TITLE
Make import path replacement hack more reliable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import os.path
 def modify_import_path_in_trelby_bin(path_to_trelby_bin: str, src_path_in_final_installation: str):
     in_file = open(path_to_trelby_bin, "rt")
     text = in_file.read()
-    text = text.replace('src', src_path_in_final_installation)
+    text = text.replace('"src"', '"'+src_path_in_final_installation+'"')
     in_file.close()
     out_file = open(path_to_trelby_bin, "wt")
     out_file.write(text)


### PR DESCRIPTION
Instead of replacing the string `src` in the file `bin/trelby` with the actual location of `src` on the target platform when installing, we now replace the string `"src"`. This is because sometimes, the replacement seems to happen multiple times, and we want to prevent replacing all occurrences of `src` in the target path again and again.

This is basically a hack inside a hack, but we want to modernise the installation process anyway (see #75), which might avoid these kinds of hacks in general.