### PR TITLE
Implement horizontal scrolling

### DIFF
--- a/src/trelby.py
+++ b/src/trelby.py
@@ -156,14 +156,14 @@ class GlobalData:
     def saveScDict(self):
         util.writeToFile(self.scDictFilename, self.scDict.save(), mainFrame)
 
-class MyPanel(wx.Panel):
+class MyPanel(wx.ScrolledWindow):
 
     def __init__(self, parent, id):
-        wx.Panel.__init__(
+        wx.ScrolledWindow.__init__(
             self, parent, id,
             # wxMSW/Windows does not seem to support
             # wx.NO_BORDER, which sucks
-            style = wx.WANTS_CHARS | wx.NO_BORDER)
+            style = wx.WANTS_CHARS | wx.NO_BORDER | wx.HSCROLL)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -178,6 +178,8 @@ class MyPanel(wx.Panel):
         self.scrollBarVertical.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
 
         self.SetSizer(hsizer)
+        self.SetScrollRate(int(self.ctrl.chX), int(self.ctrl.chY))
+        self.EnableScrolling(True, False)
 
     # we never want the scrollbar to get the keyboard focus, pass it on to
     # the main widget
@@ -435,6 +437,8 @@ class MyCtrl(wx.Control):
 
     def updateScreen(self, redraw = True, setCommon = True):
         self.adjustScrollBar()
+        self.SetMinSize(wx.Size(int(self.pageW), 10)) # the vertical min size is irrelevant currently, as vertical scrolling is still self-implemented
+        self.PostSizeEventToParent()
 
         if setCommon:
             self.updateCommon()

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -176,7 +176,6 @@ class MyPanel(wx.Panel):
         # scroll bar will automatically appear an allow scrolling.
         scrolledWindowForCtrl = wx.ScrolledWindow(self, id, style = wx.HSCROLL)
 
-        # scrollBarVertical and the (horizontally scrollable) scrolledWindowForCtrl need to be created before
         self.ctrl = MyCtrl(scrolledWindowForCtrl, -1, self.scrollBarVertical)
 
         scrolledWindowForCtrl.SetScrollRate(int(self.ctrl.chX), int(self.ctrl.chY))

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -168,7 +168,7 @@ class MyPanel(wx.ScrolledWindow):
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.scrollBarVertical = wx.ScrollBar(self, -1, style = wx.SB_VERTICAL)
-        self.ctrl = MyCtrl(self, -1)
+        self.ctrl = MyCtrl(self, -1, self.scrollBarVertical)
 
         hsizer.Add(self.ctrl, 1, wx.EXPAND)
         hsizer.Add(self.scrollBarVertical, 0, wx.EXPAND)
@@ -188,10 +188,11 @@ class MyPanel(wx.ScrolledWindow):
 
 class MyCtrl(wx.Control):
 
-    def __init__(self, parent, id):
+    def __init__(self, parent, id, scrollBarVertical: wx.ScrollBar):
         style = wx.WANTS_CHARS | wx.FULL_REPAINT_ON_RESIZE | wx.NO_BORDER
         wx.Control.__init__(self, parent, id, style = style)
 
+        self.scrollBarVertical = scrollBarVertical
         self.panel = parent
 
         self.Bind(wx.EVT_SIZE, self.OnSize)
@@ -419,7 +420,7 @@ class MyCtrl(wx.Control):
         # about draft / layout mode differences.
         approx = int(((height / self.mm2p) / self.chY) / 1.3)
 
-        self.panel.scrollBarVertical.SetScrollbar(self.sp.getTopLine(), approx,
+        self.scrollBarVertical.SetScrollbar(self.sp.getTopLine(), approx,
                                                   len(self.sp.lines) + approx - 1, approx)
 
     def clearAutoComp(self):
@@ -615,7 +616,7 @@ class MyCtrl(wx.Control):
         self.updateScreen()
 
     def OnScroll(self, event):
-        pos = self.panel.scrollBarVertical.GetThumbPosition()
+        pos = self.scrollBarVertical.GetThumbPosition()
         self.sp.setTopLine(pos)
         self.sp.clearAutoComp()
         self.updateScreen()

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -167,15 +167,15 @@ class MyPanel(wx.Panel):
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.scrollBar = wx.ScrollBar(self, -1, style = wx.SB_VERTICAL)
+        self.scrollBarVertical = wx.ScrollBar(self, -1, style = wx.SB_VERTICAL)
         self.ctrl = MyCtrl(self, -1)
 
         hsizer.Add(self.ctrl, 1, wx.EXPAND)
-        hsizer.Add(self.scrollBar, 0, wx.EXPAND)
+        hsizer.Add(self.scrollBarVertical, 0, wx.EXPAND)
 
-        self.scrollBar.Bind(wx.EVT_COMMAND_SCROLL, self.ctrl.OnScroll)
+        self.scrollBarVertical.Bind(wx.EVT_COMMAND_SCROLL, self.ctrl.OnScroll)
 
-        self.scrollBar.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
+        self.scrollBarVertical.Bind(wx.EVT_SET_FOCUS, self.OnScrollbarFocus)
 
         self.SetSizer(hsizer)
 
@@ -417,8 +417,8 @@ class MyCtrl(wx.Control):
         # about draft / layout mode differences.
         approx = int(((height / self.mm2p) / self.chY) / 1.3)
 
-        self.panel.scrollBar.SetScrollbar(self.sp.getTopLine(), approx,
-            len(self.sp.lines) + approx - 1, approx)
+        self.panel.scrollBarVertical.SetScrollbar(self.sp.getTopLine(), approx,
+                                                  len(self.sp.lines) + approx - 1, approx)
 
     def clearAutoComp(self):
         if self.sp.clearAutoComp():
@@ -611,7 +611,7 @@ class MyCtrl(wx.Control):
         self.updateScreen()
 
     def OnScroll(self, event):
-        pos = self.panel.scrollBar.GetThumbPosition()
+        pos = self.panel.scrollBarVertical.GetThumbPosition()
         self.sp.setTopLine(pos)
         self.sp.clearAutoComp()
         self.updateScreen()


### PR DESCRIPTION
Trelby uses a very complicated custom implementation for vertical scrolling, which can't be extended to work for horizontal scrolling.

In #72, there is an attempt to replace this custom implementation by using more of the toolkit's functionality. However, this is a huge projects that includes adjusting a lot of the rendering code and other parts of the application, which I'm not willing to invest right now.

This PR instead uses our wxWidgets toolkit for horizontal scrolling only, letting this implementation co-exist with the custom vertical scrolling implementation. #72 could later still be rebased on top of this in order to streamline the implementation and provide more native toolkit functionality also for vertical scrolling.

Horizontal scrolling is a necessary step towards implementing #20.